### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here is an example:
 ```
 # In your config/config.exs file
 config :my_app, :eredisx_repos, [:default, :sub_table]
-config :my_app, :
+config :my_app, MyApp.MyRepo
   repo: :default,
   pool_size: 10,
   pool_max_overflow: 15,


### PR DESCRIPTION
Is this typo?
# Update

Eh, I've force pushed a commit.

I think it is a typo and I should place here the name of Repo module, instead of leaving it blank
It will be read here: https://github.com/hagiyat/eredisx/blob/master/lib/repo.ex#L26
