### PR TITLE
Bug fix: retrieve pid from {:ok, pid} in client.ex

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -23,7 +23,7 @@ defmodule Eredisx.Client do
 
   def end_transaction(opts \\ []) do
     commands = commands_from_agent(agent_name)
-    pid = Keyword.get(opts, :pid) || :eredis.start_link
+    pid = Keyword.get(opts, :pid) || (:eredis.start_link |> elem(1))
     result = for [api|args] <- commands ++ [["exec"]] do
       query(api, args, pid: pid)
     end


### PR DESCRIPTION
`:eredis.start_link` returns `{:ok, pid}`.
We have to query with only `pid`.
