### PR TITLE
Bug fix: Use (Custom)Repo.end_transaction instead of Client.end_transaction

### DIFF
--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -99,9 +99,9 @@ defmodule Eredisx.Repo do
       """
       defmacro transaction(block) do
         quote do
-          start_transaction
+          __MODULE__.start_transaction
           unquote(Keyword.get(block, :do, nil))
-          {:ok, result} = end_transaction
+          {:ok, result} = __MODULE__.end_transaction
 
           errors = result |> Enum.filter(fn(v) -> Regex.match?(~r/\Aerr /i, v) end)
           {if(length(errors) > 0, do: :error, else: :ok), result}


### PR DESCRIPTION
**High Priority**

`transaction` macro in `Eredisx.Repo` currently **does not** use poolboy at all.

 I don't know why, but the macro (A) calls Client.end_transaction (B), instead of Repo.end_transaction (C), which does not use poolboy and creates redis connection each time.

A: https://github.com/hagiyat/eredisx/compare/master...ayamamori:repo-fixes?expand=1#diff-b2d34e808ee9864fabf0c37e286e2118R104
B: https://github.com/hagiyat/eredisx/blob/master/lib/client.ex#L24
C: https://github.com/hagiyat/eredisx/blob/master/lib/repo.ex#L52

I confirmed the issue solved by `:observer.start` and trying to execute query before/after calling Repo.start_link.

I hope it helps!
